### PR TITLE
reference popperjs from npmjs.org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3813,7 +3813,7 @@
     },
     "@popperjs/core": {
       "version": "2.5.4",
-      "resolved": "https://repo.bit.admin.ch/repository/npm-group/@popperjs/core/-/core-2.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.4.tgz",
       "integrity": "sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ=="
     },
     "@rollup/plugin-commonjs": {


### PR DESCRIPTION
@popperjs/core was resolved against repo.admin.ch in package-lock.json.
Thus `npm install` failed.